### PR TITLE
Fix issue with the_content() returning blank

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -80,7 +80,7 @@ function ctfw_content_remove_shortcodes( $content ) {
 
 	// Theme supports this?
 	if ( ! current_theme_supports( 'ctfw-non-content-shortcodes' ) ) {
-		return;
+		return $content;
 	}
 
 	$shortcodes = ctfw_shortcodes();


### PR DESCRIPTION
Found a bug where the_content() and the_excerpt() would display nothing at all, even inside The Loop, if the theme didn't support 'ctfw-non-content-shortcodes'. This fix works for me with no issues, but I'm not overly familiar with the framework yet so if there's a reason this won't work correctly, feel free to mock me.
