### PR TITLE
added slug support and original arg support to filter in get_events

### DIFF
--- a/includes/events.php
+++ b/includes/events.php
@@ -89,16 +89,24 @@ function ctfw_get_events( $args = array() ) {
 	// Filter by category
 	if ( 'all' != $args['category'] ) {
 
-		$category_term = get_term( $args['category'], 'ctc_event_category' );
+    if ( is_numeric($args['category']) ) {
+      // we have an id
+		  $category_term = get_term( (int)$args['category'], 'ctc_event_category' );
 
-		if ( $category_term ) {
-			$query_args['ctc_event_category'] = $category_term->slug;
-		}
+      if ( $category_term && !($category_term instanceof WP_Error) ) {
+        $query_args['ctc_event_category'] = $category_term->slug;
+      }
 
+    } else {
+      // we may have a term (slug)
+      if ( !empty( term_exists( $args['category'], 'ctc_event_category' ) ) ) {
+        $query_args['ctc_event_category'] = $args['category'];
+      }
+    }
 	}
 
 	// Filter get post arguments
-	$query_args = apply_filters( 'ctfw_get_events_query_args', $query_args );
+	$query_args = apply_filters( 'ctfw_get_events_query_args', $query_args, $args );
 
 	// Get events
 	$posts = get_posts( $query_args );


### PR DESCRIPTION
I am using this primarily to add options to the CTC_Events_Widget pull-down. One use case I have is I create categories where there are posts in common with events. Then I add an option to show 'events related to the category' in the widget, pre-process the 'active category' in the widget and pass it to the query as a term slug instead of an id. (the category and events taxonomies have slugs in common)

A similar or even more advanced query manipulation could be done when you add $args to the query filter. Then you can parse specific other options that the in-built logic (id, term, all, date, limit) doesn't handle.

I noticed that I use spaces and you use tabs. I can change that and update the request if needed. 
