### PR TITLE
make sure ctfw_init_widget_colorpicker is called with an jQuery-Object

### DIFF
--- a/js/admin-widgets.js
+++ b/js/admin-widgets.js
@@ -262,7 +262,7 @@ jQuery( document ).ready( function( $ ) {
 // Init colorpicker
 function ctfw_init_widget_colorpicker( widget ) {
 
-	widget.find( '.ctfw-widget-color' ).wpColorPicker( {
+	jQuery( widget ).find( '.ctfw-widget-color' ).wpColorPicker( {
 
 		// Cause Customizer to refresh
 		// Bug? With this, first color selection doesn't take effect


### PR DESCRIPTION
Some Plugins trigger `widget-added`/`widget-updated` without passing Data. Thats not nice written, but quit popular. In js/admin-widgets.js you bind the function `ctfw_init_widget_colorpicker` to these events. The Function requires an parameter `widget`, that has to be an jQuery-object, that `.find()` can work. But it's null in this special case and fails. The hole Plugin-Page freezes.